### PR TITLE
Use Router from Ember

### DIFF
--- a/app/initializers/add-announcer-to-router.js
+++ b/app/initializers/add-announcer-to-router.js
@@ -1,15 +1,16 @@
 import Ember from 'ember';
-import Router from '../router';
+
+const { inject, Router, run } = Ember;
 
 export default {
   name: 'add-announcer-to-router',
-  initialize: function(app) {
+  initialize(app) {
     Router.reopen({
-      announcer: Ember.inject.service('announcer'),
+      announcer: inject.service('announcer'),
       didTransition: function() {
         this._super(...arguments);
 
-        Ember.run.later(this, () => {
+        run.later(this, () => {
           let pageTitle = Ember.$('title').html().trim();
           let serviceMessage = this.get('announcer.message');
           let message = `${pageTitle} ${serviceMessage}`;


### PR DESCRIPTION
Was receiving an error in my project using this addon

`Uncaught Error: Could not find module 'mobile-web/router' imported from 'mobile-web/initializers/add-announcer-to-router'`
updating the initializer to reference the `Ember.Router` module instead of the project one fixed my issue not sure what potential fallout could be here?