### PR TITLE
Cancel timer for `Ember.run.later` in initializer.

### DIFF
--- a/app/initializers/add-announcer-to-router.js
+++ b/app/initializers/add-announcer-to-router.js
@@ -9,13 +9,20 @@ export default {
       didTransition: function() {
         this._super(...arguments);
 
-        Ember.run.later(this, () => {
+        this._timerId = Ember.run.later(() => {
+          if (this.isDestroying || this.isDestroyed) { return; }
+
           let pageTitle = Ember.$('title').html().trim();
           let serviceMessage = this.get('announcer.message');
           let message = `${pageTitle} ${serviceMessage}`;
 
           this.get('announcer').announce(message, 'polite');
         }, 100);
+      },
+
+      willDestroy() {
+        Ember.run.cancel(this._timerId);
+        this._super();
       }
     });
   }


### PR DESCRIPTION
This isn't the optimal fix: that's still to come, in the form of moving this out of an initializer and into `app/router.js` instead. However, this is a backwards-compatible stopgap which resolves a number of test failures which can arise if there are any bad interactions with other `Router` reopening or extension.